### PR TITLE
Use git foreach-ref in inferGitBranch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .build
 waldo-go-lib
+cmd/gitinfo/gitinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [1.3.2] - 2022-04-11
+
+### Changed
+
+- Greatly improved git branch inference.
+
 ## [1.3.1] - 2022-04-07
 
 ### Fixed
@@ -36,7 +42,8 @@ This project adheres to [Semantic Versioning].
 
 Initial public release.
 
-[Unreleased]:   https://github.com/waldoapp/waldo-go-lib/compare/v1.3.1...HEAD
+[Unreleased]:   https://github.com/waldoapp/waldo-go-lib/compare/v1.3.2...HEAD
+[1.3.2]:        https://github.com/waldoapp/waldo-go-lib/compare/v1.3.1...v1.3.2
 [1.3.1]:        https://github.com/waldoapp/waldo-go-lib/compare/v1.3.0...v1.3.1
 [1.3.0]:        https://github.com/waldoapp/waldo-go-lib/compare/v1.2.0...v1.3.0
 [1.2.0]:        https://github.com/waldoapp/waldo-go-lib/compare/v1.0.0...v1.2.0

--- a/ci.go
+++ b/ci.go
@@ -138,7 +138,7 @@ func (ci *CIInfo) extractFullInfoFromCodeBuild() {
 	trigger := os.Getenv("CODEBUILD_WEBHOOK_TRIGGER")
 
 	if strings.HasPrefix(trigger, "branch/") {
-		ci.gitBranch = trigger[len("branch/"):]
+		ci.gitBranch = strings.TrimPrefix(trigger, "branch/")
 	} else {
 		ci.gitBranch = ""
 	}

--- a/cmd/gitinfo/main.go
+++ b/cmd/gitinfo/main.go
@@ -9,15 +9,19 @@ import (
 
 func main() {
 	args := os.Args[1:]
+
 	var cd string
+
 	if len(args) > 0 {
 		cd = args[0]
+
 		if err := os.Chdir(cd); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to change directory to %s: %s\n", cd, err)
 			return
 		}
 	} else {
 		var err error
+
 		if cd, err = os.Getwd(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to get current directory: %s\n", err)
 			return

--- a/cmd/gitinfo/main.go
+++ b/cmd/gitinfo/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/waldoapp/waldo-go-lib"
+)
+
+func main() {
+	args := os.Args[1:]
+	var cd string
+	if len(args) > 0 {
+		cd = args[0]
+		if err := os.Chdir(cd); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to change directory to %s: %s\n", cd, err)
+			return
+		}
+	} else {
+		var err error
+		if cd, err = os.Getwd(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to get current directory: %s\n", err)
+			return
+		}
+	}
+
+	gitInfo := waldo.InferGitInfo(0)
+
+	fmt.Printf("Git information for %s:\n\n", cd)
+	fmt.Printf("Access: %s\n", gitInfo.Access())
+	fmt.Printf("Branch: %s\n", gitInfo.Branch())
+	fmt.Printf("Commit: %s\n", gitInfo.Commit())
+	fmt.Print("\n")
+}

--- a/git.go
+++ b/git.go
@@ -68,44 +68,7 @@ func (gi *GitInfo) Commit() string {
 
 //-----------------------------------------------------------------------------
 
-func removeDuplicate(strings []string) []string {
-	seen := make(map[string]bool)
-	var result []string
-	for _, s := range strings {
-		if _, ok := seen[s]; !ok {
-			seen[s] = true
-			result = append(result, s)
-		}
-	}
-	return result
-}
-
-func refNameToBranchName(refName string) string {
-	branchName := strings.TrimSpace(refName)
-
-	if strings.HasPrefix(branchName, "refs/heads/") {
-		branchName = strings.TrimPrefix(branchName, "refs/heads/")
-	} else if strings.HasPrefix(branchName, "refs/remotes/") {
-		branchName = strings.TrimPrefix(branchName, "refs/remotes/")
-
-		// Remove the remote name
-		slash := strings.Index(branchName, "/")
-		if slash == -1 {
-			return ""
-		}
-		branchName = branchName[slash+1:]
-	} else {
-		return ""
-	}
-
-	if branchName == "HEAD" {
-		return ""
-	}
-
-	return branchName
-}
-
-func getBranchNamesFromGitForeachRefResults(results string) []string {
+func fetchBranchNamesFromGitForEachRefResults(results string) []string {
 	lines := strings.Split(results, "\n")
 
 	var branchNames []string
@@ -118,44 +81,49 @@ func getBranchNamesFromGitForeachRefResults(results string) []string {
 		}
 	}
 
-	return removeDuplicate(branchNames)
+	return removeDuplicates(branchNames)
+}
+
+func hasGitRepository() bool {
+	_, _, err := run("git", "rev-parse")
+
+	return err == nil
+}
+
+func inferGitBranch(commit string) string {
+	if len(commit) > 0 {
+		fromForEachRev := inferGitBranchFromForEachRef(commit)
+
+		if len(fromForEachRev) > 0 {
+			return fromForEachRev
+		}
+
+		fromNameRev := inferGitBranchFromNameRev(commit)
+
+		if len(fromNameRev) > 0 {
+			return fromNameRev
+		}
+	}
+
+	return inferGitBranchFromRevParse()
 }
 
 func inferGitBranchFromForEachRef(commit string) string {
 	stdout, _, err := run("git", "for-each-ref", fmt.Sprintf("--points-at=%s", commit), "--format=%(refname)")
 
 	if err == nil {
-		branchNames := getBranchNamesFromGitForeachRefResults(stdout)
+		branchNames := fetchBranchNamesFromGitForEachRefResults(stdout)
+
 		if len(branchNames) > 0 {
-			// We don't know which branch is the right one, so just return the first one
+			//
+			// Since we don’t know which branch is the correct one, arbitrarily
+			// return the first one:
+			//
 			return branchNames[0]
 		}
 	}
 
 	return ""
-}
-
-func nameRevToBranchName(refName string) string {
-	branchName := strings.TrimSpace(refName)
-
-	if strings.HasPrefix(branchName, "tags/") {
-		return ""
-	} else if strings.HasPrefix(branchName, "remotes/") {
-		branchName = strings.TrimPrefix(branchName, "remotes/")
-
-		// Remove the remote name
-		slash := strings.Index(branchName, "/")
-		if slash == -1 {
-			return ""
-		}
-		branchName = branchName[slash+1:]
-	}
-
-	if branchName == "HEAD" {
-		return ""
-	}
-
-	return branchName
 }
 
 func inferGitBranchFromNameRev(commit string) string {
@@ -178,22 +146,6 @@ func inferGitBranchFromRevParse() string {
 	return ""
 }
 
-func inferGitBranch(commit string) string {
-	if len(commit) > 0 {
-		fromForeachRev := inferGitBranchFromForEachRef(commit)
-		if fromForeachRev != "" {
-			return fromForeachRev
-		}
-
-		fromNameRev := inferGitBranchFromNameRev(commit)
-		if fromNameRev != "" {
-			return fromNameRev
-		}
-	}
-
-	return inferGitBranchFromRevParse()
-}
-
 func inferGitCommit(skipCount int) string {
 	skip := fmt.Sprintf("--skip=%d", skipCount)
 
@@ -204,12 +156,6 @@ func inferGitCommit(skipCount int) string {
 	}
 
 	return hash
-}
-
-func hasGitRepository() bool {
-	_, _, err := run("git", "rev-parse")
-
-	return err == nil
 }
 
 func isGitInstalled() bool {
@@ -224,4 +170,77 @@ func isGitInstalled() bool {
 	_, err := exec.LookPath(name)
 
 	return err == nil
+}
+
+func nameRevToBranchName(refName string) string {
+	branchName := strings.TrimSpace(refName)
+
+	if strings.HasPrefix(branchName, "tags/") {
+		return ""
+	}
+
+	if strings.HasPrefix(branchName, "remotes/") {
+		branchName = strings.TrimPrefix(branchName, "remotes/")
+
+		//
+		// Remove the remote name:
+		//
+		slash := strings.Index(branchName, "/")
+
+		if slash == -1 {
+			return ""
+		}
+
+		branchName = branchName[slash+1:]
+	}
+
+	if branchName == "HEAD" {
+		return ""
+	}
+
+	return branchName
+}
+
+func refNameToBranchName(refName string) string {
+	branchName := strings.TrimSpace(refName)
+
+	if strings.HasPrefix(branchName, "refs/heads/") {
+		branchName = strings.TrimPrefix(branchName, "refs/heads/")
+	} else if strings.HasPrefix(branchName, "refs/remotes/") {
+		branchName = strings.TrimPrefix(branchName, "refs/remotes/")
+
+		//
+		// Remove the remote name:
+		//
+		slash := strings.Index(branchName, "/")
+
+		if slash == -1 {
+			return ""
+		}
+
+		branchName = branchName[slash+1:]
+	} else {
+		return ""
+	}
+
+	if branchName == "HEAD" {
+		return ""
+	}
+
+	return branchName
+}
+
+func removeDuplicates(strings []string) []string {
+	seen := make(map[string]bool)
+
+	var result []string
+
+	for _, s := range strings {
+		if _, ok := seen[s]; !ok {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+
+	return result
 }

--- a/git.go
+++ b/git.go
@@ -135,11 +135,34 @@ func inferGitBranchFromForEachRef(commit string) string {
 	return ""
 }
 
+func nameRevToBranchName(refName string) string {
+	branchName := strings.TrimSpace(refName)
+
+	if strings.HasPrefix(branchName, "tags/") {
+		return ""
+	} else if strings.HasPrefix(branchName, "remotes/") {
+		branchName = strings.TrimPrefix(branchName, "remotes/")
+
+		// Remove the remote name
+		slash := strings.Index(branchName, "/")
+		if slash == -1 {
+			return ""
+		}
+		branchName = branchName[slash+1:]
+	}
+
+	if branchName == "HEAD" {
+		return ""
+	}
+
+	return branchName
+}
+
 func inferGitBranchFromNameRev(commit string) string {
 	name, _, err := run("git", "name-rev", "--always", "--name-only", commit)
 
 	if err == nil {
-		return refNameToBranchName(name)
+		return nameRevToBranchName(name)
 	}
 
 	return ""

--- a/git_test.go
+++ b/git_test.go
@@ -4,56 +4,8 @@ import (
 	"testing"
 )
 
-func TestGetBranchesEmptyString(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("")
-
-	if names != nil {
-		t.Errorf("Expected nil, got %v", names)
-	}
-}
-
-func TestGetBranchesIgnoreTags(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/tags/foo")
-
-	if names != nil {
-		t.Errorf("Expected nil, got %v", names)
-	}
-}
-
-func TestGetBranchesIgnoreHeads(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/HEAD")
-
-	if names != nil {
-		t.Errorf("Expected nil, got %v", names)
-	}
-}
-
-func TestGetBranchesLocalMaster(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/heads/master")
-
-	if len(names) != 1 {
-		t.Errorf("Expected 1 element, got %v", names)
-	}
-
-	if names[0] != "master" {
-		t.Errorf("Expected [\"master\"], got %v", names)
-	}
-}
-
-func TestGetBranchesOriginMaster(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/master")
-
-	if len(names) != 1 {
-		t.Errorf("Expected 1 element, got %v", names)
-	}
-
-	if names[0] != "master" {
-		t.Errorf("Expected [\"master\"], got %v", names)
-	}
-}
-
-func TestGetBranchesCanHaveMultiple(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/master\nrefs/heads/foo\nrefs/remotes/origin/bar")
+func TestFetchBranchesCanHaveMultiple(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/remotes/origin/master\nrefs/heads/foo\nrefs/remotes/origin/bar")
 
 	if len(names) != 3 {
 		t.Errorf("Expected 1 element, got %v", names)
@@ -72,8 +24,8 @@ func TestGetBranchesCanHaveMultiple(t *testing.T) {
 	}
 }
 
-func TestGetBranchesDeduplicates(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/master\nrefs/heads/master")
+func TestFetchBranchesDeduplicate(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/remotes/origin/master\nrefs/heads/master")
 
 	if len(names) != 1 {
 		t.Errorf("Expected 1 element, got %v", names)
@@ -84,8 +36,16 @@ func TestGetBranchesDeduplicates(t *testing.T) {
 	}
 }
 
-func TestGetBranchesFull(t *testing.T) {
-	names := getBranchNamesFromGitForeachRefResults("refs/heads/master\nrefs/remotes/origin/HEAD\nrefs/remotes/origin/master\nrefs/tags/foo")
+func TestFetchBranchesEmptyString(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("")
+
+	if names != nil {
+		t.Errorf("Expected nil, got %v", names)
+	}
+}
+
+func TestFetchBranchesFull(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/heads/master\nrefs/remotes/origin/HEAD\nrefs/remotes/origin/master\nrefs/tags/foo")
 
 	if len(names) != 1 {
 		t.Errorf("Expected 1 element, got %v", names)
@@ -96,25 +56,68 @@ func TestGetBranchesFull(t *testing.T) {
 	}
 }
 
-func TestNameRevToBranchNameEmpty(t *testing.T) {
-	name := nameRevToBranchName("")
-	expected := ""
-	if name != expected {
-		t.Errorf("Expected %s string, got %v", expected, name)
+func TestFetchBranchesIgnoreHeads(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/remotes/origin/HEAD")
+
+	if names != nil {
+		t.Errorf("Expected nil, got %v", names)
 	}
 }
 
-func TestNameRevToBranchNameSimple(t *testing.T) {
-	name := nameRevToBranchName("foo")
-	expected := "foo"
-	if name != expected {
-		t.Errorf("Expected %s string, got %v", expected, name)
+func TestFetchBranchesIgnoreTags(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/tags/foo")
+
+	if names != nil {
+		t.Errorf("Expected nil, got %v", names)
+	}
+}
+
+func TestFetchBranchesLocalMaster(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/heads/master")
+
+	if len(names) != 1 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+}
+
+func TestFetchBranchesOriginMaster(t *testing.T) {
+	names := fetchBranchNamesFromGitForEachRefResults("refs/remotes/origin/master")
+
+	if len(names) != 1 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
 	}
 }
 
 func TestNameRevToBranchNameComplex(t *testing.T) {
 	name := nameRevToBranchName("features/waldo/git-handling")
 	expected := "features/waldo/git-handling"
+
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameEmpty(t *testing.T) {
+	name := nameRevToBranchName("")
+	expected := ""
+
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameHead(t *testing.T) {
+	name := nameRevToBranchName("HEAD")
+	expected := ""
+
 	if name != expected {
 		t.Errorf("Expected %s string, got %v", expected, name)
 	}
@@ -123,6 +126,16 @@ func TestNameRevToBranchNameComplex(t *testing.T) {
 func TestNameRevToBranchNameRemote(t *testing.T) {
 	name := nameRevToBranchName("remotes/origin/foo")
 	expected := "foo"
+
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameSimple(t *testing.T) {
+	name := nameRevToBranchName("foo")
+	expected := "foo"
+
 	if name != expected {
 		t.Errorf("Expected %s string, got %v", expected, name)
 	}
@@ -131,14 +144,7 @@ func TestNameRevToBranchNameRemote(t *testing.T) {
 func TestNameRevToBranchNameTags(t *testing.T) {
 	name := nameRevToBranchName("tags/bar")
 	expected := ""
-	if name != expected {
-		t.Errorf("Expected %s string, got %v", expected, name)
-	}
-}
 
-func TestNameRevToBranchNameHEAD(t *testing.T) {
-	name := nameRevToBranchName("HEAD")
-	expected := ""
 	if name != expected {
 		t.Errorf("Expected %s string, got %v", expected, name)
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,97 @@
+package waldo
+
+import (
+	"testing"
+)
+
+func TestGetBranchesEmptyString(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("")
+
+	if names != nil {
+		t.Errorf("Expected nil, got %v", names)
+	}
+}
+
+func TestGetBranchesIgnoreTags(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/tags/foo")
+
+	if names != nil {
+		t.Errorf("Expected nil, got %v", names)
+	}
+}
+
+func TestGetBranchesIgnoreHeads(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/HEAD")
+
+	if names != nil {
+		t.Errorf("Expected nil, got %v", names)
+	}
+}
+
+func TestGetBranchesLocalMaster(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/heads/master")
+
+	if len(names) != 1 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+}
+
+func TestGetBranchesOriginMaster(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/master")
+
+	if len(names) != 1 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+}
+
+func TestGetBranchesCanHaveMultiple(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/master\nrefs/heads/foo\nrefs/remotes/origin/bar")
+
+	if len(names) != 3 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+
+	if names[1] != "foo" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+
+	if names[2] != "bar" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+}
+
+func TestGetBranchesDeduplicates(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/remotes/origin/master\nrefs/heads/master")
+
+	if len(names) != 1 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+}
+
+func TestGetBranchesFull(t *testing.T) {
+	names := getBranchNamesFromGitForeachRefResults("refs/heads/master\nrefs/remotes/origin/HEAD\nrefs/remotes/origin/master\nrefs/tags/foo")
+
+	if len(names) != 1 {
+		t.Errorf("Expected 1 element, got %v", names)
+	}
+
+	if names[0] != "master" {
+		t.Errorf("Expected [\"master\"], got %v", names)
+	}
+}

--- a/git_test.go
+++ b/git_test.go
@@ -95,3 +95,51 @@ func TestGetBranchesFull(t *testing.T) {
 		t.Errorf("Expected [\"master\"], got %v", names)
 	}
 }
+
+func TestNameRevToBranchNameEmpty(t *testing.T) {
+	name := nameRevToBranchName("")
+	expected := ""
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameSimple(t *testing.T) {
+	name := nameRevToBranchName("foo")
+	expected := "foo"
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameComplex(t *testing.T) {
+	name := nameRevToBranchName("features/waldo/git-handling")
+	expected := "features/waldo/git-handling"
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameRemote(t *testing.T) {
+	name := nameRevToBranchName("remotes/origin/foo")
+	expected := "foo"
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameTags(t *testing.T) {
+	name := nameRevToBranchName("tags/bar")
+	expected := ""
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}
+
+func TestNameRevToBranchNameHEAD(t *testing.T) {
+	name := nameRevToBranchName("HEAD")
+	expected := ""
+	if name != expected {
+		t.Errorf("Expected %s string, got %v", expected, name)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -129,11 +129,7 @@ func validateBuildPath(buildPath string) (string, string, string, error) {
 		return "", "", "", err
 	}
 
-	buildSuffix := filepath.Ext(buildPath)
-
-	if strings.HasPrefix(buildSuffix, ".") {
-		buildSuffix = buildSuffix[1:]
-	}
+	buildSuffix := strings.TrimPrefix(filepath.Ext(buildPath), ".")
 
 	switch buildSuffix {
 	case "apk":

--- a/waldo.go
+++ b/waldo.go
@@ -2,7 +2,7 @@ package waldo
 
 const (
 	agentName    = "Waldo Go Lib"
-	agentVersion = "1.3.1"
+	agentVersion = "1.3.2"
 
 	defaultAPIBuildEndpoint   = "https://api.waldo.com/versions"
 	defaultAPIErrorEndpoint   = "https://api.waldo.com/uploadError"


### PR DESCRIPTION
Testing a bit I noticed that `name-rev` was returning a single result that could be a tag while  using `foreach-ref` we can get all the refs and filter only the ones that interest us.
