### PR TITLE
Handle CI_PULL_REQUEST_SOURCE_BRANCH for XCode Cloud

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -198,8 +198,17 @@ func (ci *CIInfo) extractFullInfoFromTravisCI() {
 }
 
 func (ci *CIInfo) extractFullInfoFromXcodeCloud() {
+	// https://developer.apple.com/documentation/xcode/environment-variable-reference
+
 	ci.gitBranch = os.Getenv("CI_BRANCH")
+	if ci.gitBranch == "" {
+		ci.gitBranch = os.Getenv("CI_PULL_REQUEST_SOURCE_BRANCH")
+	}
+
 	ci.gitCommit = os.Getenv("CI_COMMIT")
+	if ci.gitCommit == "" {
+		ci.gitCommit = os.Getenv("CI_PULL_REQUEST_SOURCE_COMMIT")
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Contains the name of the branch when the build is from a Pull Request according to the documentation.